### PR TITLE
add cutoffs

### DIFF
--- a/ticket_dispenser.c
+++ b/ticket_dispenser.c
@@ -94,7 +94,7 @@ void loop() {
 //
 // ticket dispensing function
 //
-					setTime(0);													// set time(); to zero for accurate cut-off timing (no ticket detector)
+					setTime(0);												// set time(); to zero for accurate cut-off timing (no ticket detector)
 					previous_status = digitalRead(opto_signal_pin);			// set prev state to what *should* default to 1 - needed for proper state machine function
 					digitalWrite(dispenser_motor, HIGH); 						// turn motor on
 					for (;tickets_dispensed < tickets_requested;) {			// start the loop to start dispensing and the state machine

--- a/ticket_dispenser.c
+++ b/ticket_dispenser.c
@@ -94,7 +94,7 @@ void loop() {
 //
 // ticket dispensing function
 //
-					setTime();													// set time(); to zero for accurate cut-off timing (no ticket detector)
+					setTime(0);													// set time(); to zero for accurate cut-off timing (no ticket detector)
 					previous_status = digitalRead(opto_signal_pin);			// set prev state to what *should* default to 1 - needed for proper state machine function
 					digitalWrite(dispenser_motor, HIGH); 						// turn motor on
 					for (;tickets_dispensed < tickets_requested;) {			// start the loop to start dispensing and the state machine


### PR DESCRIPTION
#### end of roll catch
- calculates time from last ticket dispense signal to cut off if more than 3 seconds passes
#### cancel dispensing
- hit \* key while dispensing to stop the motor and reset
